### PR TITLE
Add page updated date comment to releases page

### DIFF
--- a/app/releases/page.tsx
+++ b/app/releases/page.tsx
@@ -43,6 +43,7 @@ export default async function Releases() {
       <p>Deploy Icon by SBTS from <a href="https://thenounproject.com/browse/icons/term/deploy/" target="_blank"
         title="Deploy Icons">Noun Project</a> (CC BY 3.0)
       </p>
+      <p className="mt-1">Page updated: <FormattedDate date={new Date(Date.now())} /></p>
     </div>
   </>);
 }


### PR DESCRIPTION
The software releases page needs to be rebuilt to pull in new releases. This extra bit of information helps show when the page was last refreshed.