### PR TITLE
Update GitHub Action versions

### DIFF
--- a/.github/workflows/deploy-ghpages.yml
+++ b/.github/workflows/deploy-ghpages.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup bun
         uses: oven-sh/setup-bun@v1
@@ -30,7 +30,7 @@ jobs:
           bun run build
 
       - name: Upload build folder as pages artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         if: github.ref == 'refs/heads/main'
         with:
           path: dist${{ vars.PUBLIC_URL }}


### PR DESCRIPTION
Older versions are using deprecated Node versions